### PR TITLE
Add base url property to ApiClient

### DIFF
--- a/DragonFruit.Data/ApiClient.cs
+++ b/DragonFruit.Data/ApiClient.cs
@@ -30,10 +30,17 @@ namespace DragonFruit.Data
     public class ApiClient
     {
         private HttpClient _client;
+        private Uri _baseAddress;
 
         public ApiClient(ApiSerializer serializer)
         {
             Serializers = new SerializerResolver(serializer);
+        }
+
+        public ApiClient(ApiSerializer serializer, Uri baseAddress)
+            : this(serializer)
+        {
+            _baseAddress = baseAddress;
         }
 
         ~ApiClient()
@@ -66,6 +73,23 @@ namespace DragonFruit.Data
             {
                 Client.DefaultRequestHeaders.UserAgent.Clear();
                 Client.DefaultRequestHeaders.UserAgent.ParseAdd(value);
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the <see cref="Uri"/> that should act as the base address for relative-URI requests
+        /// </summary>
+        public Uri BaseAddress
+        {
+            get => _client?.BaseAddress ?? _baseAddress;
+            set
+            {
+                _baseAddress = value;
+
+                if (_client != null)
+                {
+                    _client.BaseAddress = value;
+                }
             }
         }
 
@@ -327,6 +351,7 @@ namespace DragonFruit.Data
             client.DefaultVersionPolicy = HttpVersionPolicy.RequestVersionOrHigher;
 #endif
 
+            client.BaseAddress = _baseAddress;
             return client;
         }
 

--- a/DragonFruit.Data/ApiClient.cs
+++ b/DragonFruit.Data/ApiClient.cs
@@ -22,7 +22,18 @@ namespace DragonFruit.Data
     /// Represents a strongly-typed serializer version of <see cref="ApiClient"/>
     /// </summary>
     /// <typeparam name="T">The type of the <see cref="ApiSerializer"/></typeparam>
-    public class ApiClient<T>() : ApiClient(new T()) where T : ApiSerializer, new();
+    public class ApiClient<T> : ApiClient where T : ApiSerializer, new()
+    {
+        public ApiClient()
+            : base(new T())
+        {
+        }
+
+        public ApiClient(Uri baseAddress)
+            : base(new T(), baseAddress)
+        {
+        }
+    }
 
     /// <summary>
     /// The <see cref="ApiClient"/> responsible for building, submitting and processing HTTP requests

--- a/DragonFruit.Data/ApiClient.cs
+++ b/DragonFruit.Data/ApiClient.cs
@@ -22,7 +22,7 @@ namespace DragonFruit.Data
     /// Represents a strongly-typed serializer version of <see cref="ApiClient"/>
     /// </summary>
     /// <typeparam name="T">The type of the <see cref="ApiSerializer"/></typeparam>
-    public class ApiClient<T>() : ApiClient(Activator.CreateInstance<T>()) where T : ApiSerializer, new();
+    public class ApiClient<T>() : ApiClient(new T()) where T : ApiSerializer, new();
 
     /// <summary>
     /// The <see cref="ApiClient"/> responsible for building, submitting and processing HTTP requests


### PR DESCRIPTION
Adds the ability to set the `BaseAddress` property when constructing the client (or by setting the property).

Includes some misc fixes to CreateDefaultHandler() that prevents it creating an invalid handler when the platform doesn't support it.